### PR TITLE
cargo: bump version-sync dependency

### DIFF
--- a/ruggine-async/Cargo.toml
+++ b/ruggine-async/Cargo.toml
@@ -22,7 +22,7 @@ tokio-timer = {version = "0.2.10", optional = true}
 failure = "0.1.5"
 
 [dev-dependencies]
-version-sync = "0.7.0"
+version-sync = "0.8.0"
 criterion = "0.2.10"
 proptest = "0.9.1"
 pretty_assertions = "0.6.1"

--- a/ruggine-errors/Cargo.toml
+++ b/ruggine-errors/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["concurrency"]
 failure = "0.1.5"
 
 [dev-dependencies]
-version-sync = "0.7.0"
+version-sync = "0.8.0"
 criterion = "0.2.10"
 cucumber_rust = "0.5.1"
 fail = "0.2.1"

--- a/ruggine-protos-core/Cargo.toml
+++ b/ruggine-protos-core/Cargo.toml
@@ -31,7 +31,7 @@ chrono = "0.4.6"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-version-sync = "0.7.0"
+version-sync = "0.8.0"
 env_logger = "0.6.1"
 
 [build-dependencies]

--- a/ruggine-sandbox/Cargo.toml
+++ b/ruggine-sandbox/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 parking_lot = {version ="0.7.1", features = ["nightly"] }
 
 [dev-dependencies]
-version-sync = "0.7.0"
+version-sync = "0.8.0"
 env_logger = "0.6.1"
 criterion = "0.2.10"
 

--- a/ruggine-service/Cargo.toml
+++ b/ruggine-service/Cargo.toml
@@ -18,7 +18,7 @@ failure = "0.1.5"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-version-sync = "0.7.0"
+version-sync = "0.8.0"
 criterion = "0.2.10"
 cucumber_rust = "0.5.1"
 fail = "0.2.1"


### PR DESCRIPTION
The new version 0.8.0 requires Rust 2018, which these projects are
already using.